### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Meower is a social media platform written in Scratch 3.0 and Python, ported to H
 3. Fixed some security vulnerabilities
 
 ## Viewing/Running the source
-The source code for beta 4.8 can be opened with TurboWarp [here](https://turbowarp.org/editor?project_url=https://meower.org/Meower/Meower%20Beta%20Test%204.8.sb3&extension=https://mikedev101.github.io/cloudlink/B3-0.js).
+The source code for beta 4.8 can be opened with TurboWarp [here](https://turbowarp.org/editor?project_url=meower.org/Meower/Meower%20Beta%20Test%204.8.sb3&extension=https://mikedev101.github.io/cloudlink/B3-0.js).
 
 ### Opening the source with a diffrent editor
 1. Download the source code file (*.sb3)

--- a/README.md
+++ b/README.md
@@ -9,18 +9,23 @@ Meower is a social media platform written in Scratch 3.0 and Python, ported to H
 3. Fixed some security vulnerabilities
 
 ## Viewing/Running the source
+The source code for beta 4.8 can be opened with TurboWarp [here](https://turbowarp.org/editor?project_url=https://meower.org/Meower/Meower%20Beta%20Test%204.8.sb3&extension=https://mikedev101.github.io/cloudlink/B3-0.js).
+
+### Opening the source with a diffrent editor
 1. Download the source code file (*.sb3)
 2. Load a compatible Scratch editor.
-3. Open the source code file.
+4. Load CloudLink (This isn't nesseary if you're using Adacraft.)
+5. Open the source code file.
 
 #### Compatible editors:
-* [Turbowarp](https://turbowarp.org/editor?extension=https://mikedev101.github.io/cloudlink/B3-0.js)
-* [SheepTester's E羊icques](https://sheeptester.github.io/scratch-gui/index.html?extension=https%3A%2F%2Fmikedev101.github.io%2Fcloudlink%2FB3-0.js)
-* [Ogadaki's Adacraft (Accessible in the Extensions menu)](https://adacraft.org/)
+* [TurboWarp](https://turbowarp.org/editor?extension=https://mikedev101.github.io/cloudlink/B3-0.js)
+* [Adacraft](https://adacraft.org/studio?size=480x360)
+* [TurboWarp Desktop](https://desktop.turbowarp.org)
 
 ## Contributing to the source
 1. Fork the repository.
-2. Follow the instructions above to load the source code.
-3. Make changes (Use GitHub Desktop to upload large files).
-4. Make a pull request, and explain the changes you made.
-5. If it gets approved, the source will be merged.
+2. Create a new branch.
+3. Follow the instructions above to load the source code.
+4. Make changes (Use GitHub Desktop to upload large files).
+5. Make a pull request, and explain the changes you made.
+6. If it gets approved, the source will be merged.


### PR DESCRIPTION
TurboWarp can load Scratch projects from almost anywhere using the [project_url parameter](https://docs.turbowarp.org/url-parameters#project_url), so I put a direct link in the README so the Meower source can be viewed with just one click. This PR also removes E羊icques and adds TurboWap Desktop to the list of compatible editors and adds creating a new branch to the contributing instructions.